### PR TITLE
Switch AI gateway models from DeepSeek to GLM 5.3 Flash

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -33,14 +33,14 @@ export const myProvider = isTestEnvironment
   : customProvider({
       languageModels: {
         "chat-model": wrapLanguageModel({
-          model: gateway.languageModel("deepseek/deepseek-v4-flash-0731"),
+          model: gateway.languageModel("zai/glm-5.3-flash"),
           middleware,
         }),
         "chat-model-reasoning": wrapLanguageModel({
-          model: gateway.languageModel("deepseek/deepseek-v4-flash-0731"),
+          model: gateway.languageModel("zai/glm-5.3-flash"),
           middleware,
         }),
-        "title-model": gateway.languageModel("deepseek/deepseek-v4-flash-0731"),
-        "artifact-model": gateway.languageModel("deepseek/deepseek-v4-flash-0731"),
+        "title-model": gateway.languageModel("zai/glm-5.3-flash"),
+        "artifact-model": gateway.languageModel("zai/glm-5.3-flash"),
       },
     });


### PR DESCRIPTION
Update all four language model slots (chat, chat-reasoning, title, artifact) to use zai/glm-5.3-flash instead of
deepseek/deepseek-v4-flash-0731.


Claude-Session: https://claude.ai/code/session_01QsKL4CpPG4rFV2Y4nvnVzA